### PR TITLE
Make code compatible with Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,15 @@ dist: trusty
 language: python
 cache: pip
 python:
-- '2.7'
+  - '2.7'
+  - '3.6'
 install:
-- pip install -r requirements.txt
-- pip install coveralls
+  - pip install -r requirements.txt
+  - pip install coveralls
 script:
-- pytest .
+  - pytest .
 after_success:
-- coveralls
+  - coveralls
 deploy:
   provider: pypi
   skip_upload_docs: true

--- a/tests/test_sqsfeedexport.py
+++ b/tests/test_sqsfeedexport.py
@@ -155,7 +155,7 @@ def test_sqsfeedstorage_and_sqsexporter():
 
         # now check what we've got
         messages = queue.receive_messages(MaxNumberOfMessages=10, MessageAttributeNames=['All'])
-        for index in xrange(6):
+        for index in range(6):
             assert messages[index].body == 'ScrapyItem'
             assert messages[index].message_attributes == \
                    sqsfeedexport.translate_item_to_message(examples[index])['MessageAttributes']

--- a/tests/test_sqsfeedexport.py
+++ b/tests/test_sqsfeedexport.py
@@ -6,6 +6,7 @@ from scrapy.extensions.feedexport import IFeedStorage
 from zope.interface.verify import verifyObject
 
 import sqsfeedexport
+from six.moves import range
 
 examples = [
     {


### PR DESCRIPTION
This fixes #1.

Basically using more `six` compatibility functions, as the library was already using it.

Tests are passing for me on Python 2.7.14 and 3.6.4 in macOS High Sierra.